### PR TITLE
feat: Add single note to Startup

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -47,6 +47,8 @@ public class Messages {
                 .append(person.getEmail())
                 .append("; Address: ")
                 .append(person.getAddress())
+                .append("; Note: ")
+                .append(person.getNote())
                 .append("; Tags: ");
         person.getTags().forEach(builder::append);
         return builder.toString();

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -32,11 +32,13 @@ public class AddCommand extends Command {
             + PREFIX_ADDRESS + "ADDRESS "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
-            + PREFIX_NAME + "John Doe "
+            + PREFIX_NAME + "Allium "
+            + PREFIX_INDUSTRY + "WEB3 "
+            + PREFIX_FUNDING_STAGE + "SEED "
             + PREFIX_PHONE + "98765432 "
-            + PREFIX_EMAIL + "johnd@example.com "
-            + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
-            + PREFIX_TAG + "friends "
+            + PREFIX_EMAIL + "allium@gmail.com "
+            + PREFIX_ADDRESS + "420, 23rd Street, #02-25 "
+            + PREFIX_TAG + "competitive "
             + PREFIX_TAG + "owesMoney";
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";

--- a/src/main/java/seedu/address/logic/commands/NoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/NoteCommand.java
@@ -27,7 +27,7 @@ import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
 
 /**
- * Adds a Note to a startup in the address book.
+ * Adds a Note to a startup in the address book!
  */
 public class NoteCommand extends Command {
 

--- a/src/main/java/seedu/address/logic/commands/NoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/NoteCommand.java
@@ -1,0 +1,280 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.CollectionUtil;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.FundingStage;
+import seedu.address.model.person.Industry;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Note;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Adds a Note to a startup in the address book.
+ */
+public class NoteCommand extends Command {
+
+    public static final String COMMAND_WORD = "note";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the notes of the person identified "
+            + "by the index number used in the displayed person list. "
+            + "Existing values will be overwritten by the input values.\n"
+            + "Parameters: INDEX (must be a positive integer) "
+            + "[NOTE]...\n"
+            + "Example: " + COMMAND_WORD + " 1 "
+            + "Lovely Smell ";
+
+    public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Note of Person: %1$s";
+    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
+    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
+
+    private final Index index;
+    private final EditPersonDescriptor editPersonDescriptor;
+
+    /**
+     * @param index of the person in the filtered person list to edit
+     * @param editPersonDescriptor details to edit the person with
+     */
+    public NoteCommand(Index index, EditPersonDescriptor editPersonDescriptor) {
+        requireNonNull(index);
+        requireNonNull(editPersonDescriptor);
+
+        this.index = index;
+        this.editPersonDescriptor = new EditPersonDescriptor(editPersonDescriptor);
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Person personToEdit = lastShownList.get(index.getZeroBased());
+        Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
+
+        if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
+            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+        }
+
+        model.setPerson(personToEdit, editedPerson);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
+    }
+
+    /**
+     * Creates and returns a {@code Person} with the details of {@code personToEdit}
+     * edited with {@code editPersonDescriptor}.
+     */
+    private static Person createEditedPerson(Person personToEdit, EditPersonDescriptor editPersonDescriptor) {
+        assert personToEdit != null;
+
+        Name updatedName = editPersonDescriptor.getName().orElse(personToEdit.getName());
+        Phone updatedPhone = editPersonDescriptor.getPhone().orElse(personToEdit.getPhone());
+        FundingStage updatedFundingStage = editPersonDescriptor.getFundingStage().orElse(
+                personToEdit.getFundingStage());
+        Industry updatedIndustry = editPersonDescriptor.getIndustry().orElse(personToEdit.getIndustry());
+        Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
+        Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
+        Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
+        Note updatedNote = editPersonDescriptor.getNote().orElse(personToEdit.getNote());
+
+        return new Person(updatedName, updatedFundingStage, updatedIndustry,
+                updatedPhone, updatedEmail, updatedAddress, updatedTags, updatedNote);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof NoteCommand)) {
+            return false;
+        }
+
+        NoteCommand otherNoteCommand = (NoteCommand) other;
+        return index.equals(otherNoteCommand.index)
+                && editPersonDescriptor.equals(otherNoteCommand.editPersonDescriptor);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("index", index)
+                .add("editPersonDescriptor", editPersonDescriptor)
+                .toString();
+    }
+
+    /**
+     * Stores the details to edit the person with. Each non-empty field value will replace the
+     * corresponding field value of the person.
+     */
+    public static class EditPersonDescriptor {
+        private Name name;
+
+        private Industry industry;
+
+        private FundingStage fundingStage;
+
+        private Phone phone;
+        private Email email;
+        private Address address;
+        private Set<Tag> tags;
+
+        private Note note;
+
+        public EditPersonDescriptor() {}
+
+        /**
+         * Copy constructor.
+         * A defensive copy of {@code tags} is used internally.
+         */
+        public EditPersonDescriptor(EditPersonDescriptor toCopy) {
+            setName(toCopy.name);
+            setFundingStage(toCopy.fundingStage);
+            setIndustry(toCopy.industry);
+            setPhone(toCopy.phone);
+            setEmail(toCopy.email);
+            setAddress(toCopy.address);
+            setTags(toCopy.tags);
+            setNote(toCopy.note);
+        }
+
+        /**
+         * Returns true if at least one field is edited.
+         */
+        public boolean isAnyFieldEdited() {
+            return CollectionUtil.isAnyNonNull(name, industry, fundingStage, phone, email, address, tags, note);
+        }
+
+        public void setIndustry(Industry industry) {
+            this.industry = industry;
+        }
+
+        public void setFundingStage(FundingStage fundingStage) {
+            this.fundingStage = fundingStage;
+        }
+
+        public void setName(Name name) {
+            this.name = name;
+        }
+
+        public Optional<Name> getName() {
+            return Optional.ofNullable(name);
+        }
+
+        public void setNote(Note note) {
+            this.note = note;
+        }
+
+        public Optional<Note> getNote() {
+            return Optional.ofNullable(note);
+        }
+
+        public Optional<Industry> getIndustry() {
+            return Optional.ofNullable(industry);
+        }
+
+        public Optional<FundingStage> getFundingStage() {
+            return Optional.ofNullable(fundingStage);
+        }
+
+        public void setPhone(Phone phone) {
+            this.phone = phone;
+        }
+
+        public Optional<Phone> getPhone() {
+            return Optional.ofNullable(phone);
+        }
+
+        public void setEmail(Email email) {
+            this.email = email;
+        }
+
+        public Optional<Email> getEmail() {
+            return Optional.ofNullable(email);
+        }
+
+        public void setAddress(Address address) {
+            this.address = address;
+        }
+
+        public Optional<Address> getAddress() {
+            return Optional.ofNullable(address);
+        }
+
+        /**
+         * Sets {@code tags} to this object's {@code tags}.
+         * A defensive copy of {@code tags} is used internally.
+         */
+        public void setTags(Set<Tag> tags) {
+            this.tags = (tags != null) ? new HashSet<>(tags) : null;
+        }
+
+        /**
+         * Returns an unmodifiable tag set, which throws {@code UnsupportedOperationException}
+         * if modification is attempted.
+         * Returns {@code Optional#empty()} if {@code tags} is null.
+         */
+        public Optional<Set<Tag>> getTags() {
+            return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (other == this) {
+                return true;
+            }
+
+            // instanceof handles nulls
+            if (!(other instanceof EditPersonDescriptor)) {
+                return false;
+            }
+
+            EditPersonDescriptor otherEditPersonDescriptor = (EditPersonDescriptor) other;
+            return Objects.equals(name, otherEditPersonDescriptor.name)
+                    && Objects.equals(phone, otherEditPersonDescriptor.phone)
+                    && Objects.equals(fundingStage, otherEditPersonDescriptor.fundingStage)
+                    && Objects.equals(industry, otherEditPersonDescriptor.industry)
+                    && Objects.equals(email, otherEditPersonDescriptor.email)
+                    && Objects.equals(address, otherEditPersonDescriptor.address)
+                    && Objects.equals(tags, otherEditPersonDescriptor.tags)
+                    && Objects.equals(note, otherEditPersonDescriptor.note);
+        }
+
+        @Override
+        public String toString() {
+            return new ToStringBuilder(this)
+                    .add("name", name)
+                    .add("industry", industry)
+                    .add("funding stage", fundingStage)
+                    .add("phone", phone)
+                    .add("email", email)
+                    .add("address", address)
+                    .add("tags", tags)
+                    .add("note", note)
+                    .toString();
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/NoteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/NoteCommand.java
@@ -27,7 +27,7 @@ import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
 
 /**
- * Adds a Note to a startup in the address book!
+ * Edits a Note of a startup in the address book!
  */
 public class NoteCommand extends Command {
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,6 +17,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.NoteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -76,6 +77,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case NoteCommand.COMMAND_WORD:
+            return new NoteCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/NoteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/NoteCommandParser.java
@@ -1,0 +1,41 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.NoteCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Note;
+
+/**
+ * Parses input arguments and creates a new NoteCommand object
+ */
+public class NoteCommandParser implements Parser<NoteCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the NoteCommand
+     * and returns a NoteCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public NoteCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        NoteCommand.EditPersonDescriptor editPersonDescriptor = new NoteCommand.EditPersonDescriptor();
+        String[] argParts = args.trim().split("\\s+", 2); // Split into index and note description
+
+        if (argParts.length != 2 || !argParts[0].matches("\\d+")) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, NoteCommand.MESSAGE_USAGE));
+        }
+
+        Index index;
+        try {
+            index = ParserUtil.parseIndex(argParts[0]);
+            Note newNote = new Note(argParts[1]);
+            editPersonDescriptor.setNote(newNote);
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, NoteCommand.MESSAGE_USAGE), pe);
+        }
+        return new NoteCommand(index, new NoteCommand.EditPersonDescriptor(editPersonDescriptor));
+    }
+}
+

--- a/src/main/java/seedu/address/model/person/Note.java
+++ b/src/main/java/seedu/address/model/person/Note.java
@@ -1,0 +1,66 @@
+package seedu.address.model.person;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents a Note of a Startup in the address book.
+ * Guarantees: immutable; is valid as declared in {@link #isValidNote(String)}
+ */
+public class Note {
+
+    public static final String MESSAGE_CONSTRAINTS = "Notes can take any values, and it should not be blank";
+
+    /*
+     * The first character of the note must not be a whitespace,
+     * otherwise " " (a blank string) becomes a valid input.
+     */
+    public static final String VALIDATION_REGEX = "[^\\s].*";
+
+    public final String value;
+
+    /**
+     * Constructs an {@code Note}.
+     *
+     * @param note A valid note.
+     */
+    public Note(String note) {
+        requireNonNull(note);
+        checkArgument(isValidNote(note), MESSAGE_CONSTRAINTS);
+        value = note;
+    }
+
+    /**
+     * Returns true if a given string is a valid email.
+     */
+    public static boolean isValidNote(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof Note)) {
+            return false;
+        }
+
+        Note otherNote = (Note) other;
+        return value.equals(otherNote.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+}
+

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -24,11 +24,10 @@ public class Person {
     // Data fields
 
     private final FundingStage fundingStage;
-
     private final Industry industry;
-
     private final Address address;
     private final Set<Tag> tags = new HashSet<>();
+    private final Note note;
 
     /**
      * Every field must be present and not null.
@@ -43,6 +42,23 @@ public class Person {
         this.email = email;
         this.address = address;
         this.tags.addAll(tags);
+        this.note = new Note("Add a Note!");
+    }
+
+    /**
+     * Every field must be present and not null.
+     */
+    public Person(Name name, FundingStage fundingStage, Industry industry,
+                  Phone phone, Email email, Address address, Set<Tag> tags, Note note) {
+        requireAllNonNull(name, fundingStage, industry, phone, email, address, tags);
+        this.name = name;
+        this.fundingStage = fundingStage;
+        this.industry = industry;
+        this.phone = phone;
+        this.email = email;
+        this.address = address;
+        this.tags.addAll(tags);
+        this.note = note;
     }
 
     public FundingStage getFundingStage() {
@@ -67,6 +83,10 @@ public class Person {
 
     public Address getAddress() {
         return address;
+    }
+
+    public Note getNote() {
+        return note;
     }
 
     /**
@@ -131,6 +151,7 @@ public class Person {
                 .add("email", email)
                 .add("address", address)
                 .add("tags", tags)
+                .add("note", note)
                 .toString();
     }
 

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -150,8 +150,8 @@ public class Person {
                 .add("phone", phone)
                 .add("email", email)
                 .add("address", address)
-                .add("tags", tags)
                 .add("note", note)
+                .add("tags", tags)
                 .toString();
     }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -15,6 +15,7 @@ import seedu.address.model.person.Email;
 import seedu.address.model.person.FundingStage;
 import seedu.address.model.person.Industry;
 import seedu.address.model.person.Name;
+import seedu.address.model.person.Note;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
@@ -35,6 +36,8 @@ class JsonAdaptedPerson {
     private final String phone;
     private final String email;
     private final String address;
+
+    private final String note;
     private final List<JsonAdaptedTag> tags = new ArrayList<>();
 
     /**
@@ -44,6 +47,7 @@ class JsonAdaptedPerson {
     public JsonAdaptedPerson(@JsonProperty("name") String name, @JsonProperty("industry") String industry,
             @JsonProperty("fundingStage") String fundingStage, @JsonProperty("phone") String phone,
             @JsonProperty("email") String email, @JsonProperty("address") String address,
+                             @JsonProperty("note") String note,
             @JsonProperty("tags") List<JsonAdaptedTag> tags) {
         this.name = name;
         this.fundingStage = fundingStage;
@@ -51,6 +55,7 @@ class JsonAdaptedPerson {
         this.phone = phone;
         this.email = email;
         this.address = address;
+        this.note = note;
         if (tags != null) {
             this.tags.addAll(tags);
         }
@@ -64,6 +69,7 @@ class JsonAdaptedPerson {
         phone = source.getPhone().value;
         email = source.getEmail().value;
         address = source.getAddress().value;
+        note = source.getNote().value;
         industry = source.getIndustry().value;
         fundingStage = source.getFundingStage().value;
         tags.addAll(source.getTags().stream()
@@ -132,8 +138,17 @@ class JsonAdaptedPerson {
         }
         final Address modelAddress = new Address(address);
 
+        if (note == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Note.class.getSimpleName()));
+        }
+        if (!Note.isValidNote(note)) {
+            throw new IllegalValueException(Address.MESSAGE_CONSTRAINTS);
+        }
+        final Note modelNote = new Note(note);
+
         final Set<Tag> modelTags = new HashSet<>(personTags);
-        return new Person(modelName, modelFundingStage, modelIndustry, modelPhone, modelEmail, modelAddress, modelTags);
+        return new Person(modelName, modelFundingStage, modelIndustry,
+                modelPhone, modelEmail, modelAddress, modelTags, modelNote);
     }
 
 }

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -3,10 +3,13 @@ package seedu.address.ui;
 import java.util.Comparator;
 
 import javafx.fxml.FXML;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
 import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
 import seedu.address.model.person.Person;
 
 /**
@@ -40,6 +43,9 @@ public class PersonCard extends UiPart<Region> {
     private Label email;
     @FXML
     private FlowPane industryAndFundingStage;
+
+    @FXML
+    private Label note; // Add this field for note
     @FXML
     private FlowPane tags;
 
@@ -57,8 +63,34 @@ public class PersonCard extends UiPart<Region> {
         industryAndFundingStage.getChildren().addAll(
                 new Label(person.getIndustry().value),
                 new Label("SERIES " + person.getFundingStage().value));
+        createNoteSection();
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
     }
+
+    private void createNoteSection() {
+        // Create note label
+        note = new Label(person.getNote().value);
+        note.setVisible(true); // Note is always visible
+        note.setWrapText(true); // Allow text wrapping if too long
+
+        // Layout note section
+        VBox noteSection = new VBox();
+        noteSection.setAlignment(Pos.TOP_LEFT); // Align content to the top left
+        noteSection.setPadding(new Insets(10)); // Add padding around the note section
+        noteSection.setPrefWidth(200); // Set preferred width for the note section
+        noteSection.setStyle("-fx-border-color: Transparent;"
+                + "-fx-border-width: 1px;"); // Add border around the note section
+
+        // Add note label to the note section
+        noteSection.getChildren().addAll(new Label(""), note);
+
+        // Add some padding between note section and person card box
+        VBox.setMargin(noteSection, new Insets(10));
+
+        // Add note section to cardPane
+        cardPane.getChildren().add(noteSection);
+    }
+
 }

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
@@ -6,6 +6,7 @@
     "fundingStage": "A",
     "email": "alice@example.com",
     "address": "123, Jurong West Ave 6, #08-111",
+    "note": "Add a note!",
     "tags": [ "friends" ]
   }, {
     "name": "Alice Pauline",
@@ -13,6 +14,7 @@
     "industry": "finance",
     "fundingStage": "A",
     "email": "pauline@example.com",
-    "address": "4th street"
+    "address": "4th street",
+    "note": "Add a note!"
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/invalidPersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/invalidPersonAddressBook.json
@@ -5,6 +5,7 @@
     "industry": "finance",
     "fundingStage": "A",
     "email": "invalid@email!3e",
-    "address": "4th street"
+    "address": "4th street",
+    "note": "Add a note!"
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -7,6 +7,7 @@
     "fundingStage": "A",
     "email" : "alice@example.com",
     "address" : "123, Jurong West Ave 6, #08-111",
+    "note": "Add a note!",
     "tags" : [ "friends" ]
   }, {
     "name" : "Benson Meier",
@@ -15,6 +16,7 @@
     "fundingStage": "A",
     "email" : "johnd@example.com",
     "address" : "311, Clementi Ave 2, #02-25",
+    "note": "Add a note!",
     "tags" : [ "owesMoney", "friends" ]
   }, {
     "name" : "Carl Kurz",
@@ -23,6 +25,7 @@
     "fundingStage": "A",
     "email" : "heinz@example.com",
     "address" : "wall street",
+    "note": "Add a note!",
     "tags" : [ ]
   }, {
     "name" : "Daniel Meier",
@@ -31,6 +34,7 @@
     "fundingStage": "A",
     "email" : "cornelia@example.com",
     "address" : "10th street",
+    "note": "Add a note!",
     "tags" : [ "friends" ]
   }, {
     "name" : "Elle Meyer",
@@ -39,6 +43,7 @@
     "fundingStage": "A",
     "email" : "werner@example.com",
     "address" : "michegan ave",
+    "note": "Add a note!",
     "tags" : [ ]
   }, {
     "name" : "Fiona Kunz",
@@ -47,6 +52,7 @@
     "fundingStage": "A",
     "email" : "lydia@example.com",
     "address" : "little tokyo",
+    "note": "Add a note!",
     "tags" : [ ]
   }, {
     "name" : "George Best",
@@ -55,6 +61,7 @@
     "fundingStage": "A",
     "email" : "anna@example.com",
     "address" : "4th street",
+    "note": "Add a note!",
     "tags" : [ ]
   } ]
 }

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -92,11 +92,15 @@ public class PersonTest {
 
     @Test
     public void toStringMethod() {
-        String expected = Person.class.getCanonicalName() + "{name=" + ALICE.getName()
-                + ", industry=" + ALICE.getIndustry() + ", funding stage=" + ALICE.getFundingStage()
+        String expected = Person.class.getCanonicalName()
+                + "{name=" + ALICE.getName()
+                + ", industry=" + ALICE.getIndustry()
+                + ", funding stage=" + ALICE.getFundingStage()
                 + ", phone=" + ALICE.getPhone()
-                + ", email=" + ALICE.getEmail() + ", address=" + ALICE.getAddress() + ", tags="
-                + ALICE.getTags() + "}";
+                + ", email=" + ALICE.getEmail()
+                + ", address=" + ALICE.getAddress()
+                + ", note=" + ALICE.getNote()
+                + ", tags=" + ALICE.getTags() + "}";
         assertEquals(expected, ALICE.toString());
     }
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -36,6 +36,8 @@ public class JsonAdaptedPersonTest {
     private static final String VALID_FUNDING = BENSON.getFundingStage().toString();
 
     private static final String VALID_INDUSTRY = BENSON.getIndustry().toString();
+
+    private static final String VALID_NOTE = BENSON.getNote().toString();
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
@@ -50,7 +52,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(INVALID_NAME, VALID_INDUSTRY, VALID_FUNDING,
-                    VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+                    VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_NOTE);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -52,7 +52,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(INVALID_NAME, VALID_INDUSTRY, VALID_FUNDING,
-                    VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_NOTE);
+                    VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_NOTE, VALID_TAGS);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -60,7 +60,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_INDUSTRY, VALID_FUNDING,
-            VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+            VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_NOTE, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -69,7 +69,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_INDUSTRY, VALID_FUNDING,
-                    INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+                    INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_NOTE, VALID_TAGS);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -77,7 +77,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_INDUSTRY, VALID_FUNDING,
-            null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+            null, VALID_EMAIL, VALID_ADDRESS, VALID_NOTE, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -86,7 +86,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_INDUSTRY, VALID_FUNDING,
-                    VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+                    VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_NOTE, VALID_TAGS);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -94,7 +94,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_INDUSTRY, VALID_FUNDING,
-            VALID_PHONE, null, VALID_ADDRESS, VALID_TAGS);
+            VALID_PHONE, null, VALID_ADDRESS, VALID_NOTE, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -103,7 +103,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_INDUSTRY, VALID_FUNDING,
-                    VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS);
+                    VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_NOTE, VALID_TAGS);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -111,7 +111,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_INDUSTRY, VALID_FUNDING,
-            VALID_PHONE, VALID_EMAIL, null, VALID_TAGS);
+            VALID_PHONE, VALID_EMAIL, null, VALID_NOTE, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -122,7 +122,7 @@ public class JsonAdaptedPersonTest {
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_INDUSTRY, VALID_FUNDING,
-                    VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags);
+                    VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_NOTE, invalidTags);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -8,6 +8,7 @@ import seedu.address.model.person.Email;
 import seedu.address.model.person.FundingStage;
 import seedu.address.model.person.Industry;
 import seedu.address.model.person.Name;
+import seedu.address.model.person.Note;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
@@ -27,6 +28,8 @@ public class PersonBuilder {
 
     public static final String DEFAULT_FUNDING = "A";
 
+    public static final String DEFAULT_NOTE = "Add a note!";
+
     private Name name;
     private Phone phone;
 
@@ -36,6 +39,8 @@ public class PersonBuilder {
 
     private Email email;
     private Address address;
+
+    private Note note;
     private Set<Tag> tags;
 
     /**
@@ -49,6 +54,7 @@ public class PersonBuilder {
         email = new Email(DEFAULT_EMAIL);
         address = new Address(DEFAULT_ADDRESS);
         tags = new HashSet<>();
+        note = new Note(DEFAULT_NOTE);
     }
 
     /**
@@ -61,6 +67,7 @@ public class PersonBuilder {
         phone = personToCopy.getPhone();
         email = personToCopy.getEmail();
         address = personToCopy.getAddress();
+        note = personToCopy.getNote();
         tags = new HashSet<>(personToCopy.getTags());
     }
 
@@ -101,6 +108,14 @@ public class PersonBuilder {
      */
     public PersonBuilder withEmail(String email) {
         this.email = new Email(email);
+        return this;
+    }
+
+    /**
+     * Sets the {@code Note} of the {@code Person} that we are building.
+     */
+    public PersonBuilder withNote(String note) {
+        this.note = new Note(note);
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -26,7 +26,7 @@ public class TypicalPersons {
     public static final Person ALICE = new PersonBuilder().withName("Alice Pauline")
             .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
             .withPhone("94351253").withIndustry("finance").withFundingStage("A")
-            .withTags("friends").build();
+            .withNote("Add a note!").withTags("friends").build();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25").withIndustry("finance").withFundingStage("A")
             .withEmail("johnd@example.com").withPhone("98765432").withNote("Smelly guy")

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -29,7 +29,7 @@ public class TypicalPersons {
             .withTags("friends").build();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25").withIndustry("finance").withFundingStage("A")
-            .withEmail("johnd@example.com").withPhone("98765432")
+            .withEmail("johnd@example.com").withPhone("98765432").withNote("Smelly guy")
             .withTags("owesMoney", "friends").build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withIndustry("finance").withFundingStage("A")


### PR DESCRIPTION
- Added new command to add a note to the startup after a startup has been created.
- Notes are stored as String and stored in the Person model
- Notes are added only after the startup is created using the add command. By default note is "Add a Note!"
- Note command syntax is as follows: note [INDEX] [DESCRIPTION]
- Notes will be displayed on the right hand side of the PersonCard as seen in the picture
- Notes are saved together with the other features in addressbook.json:
- `{
  "persons" : [ {
    "name" : "Confido",
    "industry" : "FINTECH",
    "fundingStage" : "B",
    "phone" : "999",
    "email" : "confido@gmail.com",
    "address" : "New York City Road 2",
    "note" : "Confido seems really cool right now. Looking forward to the interview",
    "tags" : [ "INTERVIEW" ]
  }, {
    "name" : "Narmi",
    "industry" : "FINTECH",
    "fundingStage" : "C",
    "phone" : "888",
    "email" : "narmi@gmail.com",
    "address" : "New York City Road 3",
    "note" : "Narmi is cool",
    "tags" : [ "TALKING" ]
  } ]
}`
- Further discussions on functionality of notes to be discussed e.g. Multiple notes per startup(?), for multiple notes -> scroll through notes feature(?)
- More test cases for Notes to be implemented
- Closes https://github.com/AY2324S2-CS2103T-W09-2/tp/issues/23

<img width="709" alt="image" src="https://github.com/AY2324S2-CS2103T-W09-2/tp/assets/84655602/6ad6b9be-c62e-47d2-99a6-3c06443dd928">

