### PR TITLE
feat: Add more funding levels

### DIFF
--- a/src/main/java/seedu/address/model/person/FundingStage.java
+++ b/src/main/java/seedu/address/model/person/FundingStage.java
@@ -9,7 +9,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class FundingStage {
 
     public static final String MESSAGE_CONSTRAINTS =
-        "Funding stages should be either 'A', 'B' or 'C'.";
+        "Funding stages should be either 'A', 'B', 'S', 'PS' or 'C'.";
 
     public final String value;
 
@@ -28,7 +28,9 @@ public class FundingStage {
      * Returns true if a given industry is a valid industry.
      */
     public static boolean isValidFundingLevel(String fundingLevel) {
-        return fundingLevel.equals("A") || fundingLevel.equals("B") || fundingLevel.equals("C");
+        fundingLevel = fundingLevel.toUpperCase();
+        return fundingLevel.equals("A") || fundingLevel.equals("B") || fundingLevel.equals("C")
+            || fundingLevel.equals("S") || fundingLevel.equals("PS");
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -60,9 +60,18 @@ public class PersonCard extends UiPart<Region> {
         phone.setText(person.getPhone().value);
         address.setText(person.getAddress().value);
         email.setText(person.getEmail().value);
+
+        String fundingLevel = person.getFundingStage().value;
+        if (fundingLevel.equals("PS")) {
+            fundingLevel = "PRE-SEED";
+        } else if (fundingLevel.equals("S")) {
+            fundingLevel = "SEED";
+        } else {
+            fundingLevel = "SERIES " + fundingLevel;
+        }
         industryAndFundingStage.getChildren().addAll(
                 new Label(person.getIndustry().value),
-                new Label("SERIES " + person.getFundingStage().value));
+                new Label(fundingLevel));
         createNoteSection();
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))

--- a/src/test/java/seedu/address/model/person/FundingStageTest.java
+++ b/src/test/java/seedu/address/model/person/FundingStageTest.java
@@ -30,11 +30,19 @@ public class FundingStageTest {
         assertFalse(FundingStage.isValidFundingLevel("AB")); // invalid funding level
         assertFalse(FundingStage.isValidFundingLevel("1")); // numbers
         assertFalse(FundingStage.isValidFundingLevel("D")); // invalid funding level
+        assertFalse(FundingStage.isValidFundingLevel("pss")); // invalid funding level
 
         // valid funding levels
         assertTrue(FundingStage.isValidFundingLevel("A"));
         assertTrue(FundingStage.isValidFundingLevel("B"));
+        assertTrue(FundingStage.isValidFundingLevel("b"));
         assertTrue(FundingStage.isValidFundingLevel("C"));
+        assertTrue(FundingStage.isValidFundingLevel("s"));
+        assertTrue(FundingStage.isValidFundingLevel("S"));
+        assertTrue(FundingStage.isValidFundingLevel("PS"));
+        assertTrue(FundingStage.isValidFundingLevel("pS"));
+        assertTrue(FundingStage.isValidFundingLevel("Ps"));
+        assertTrue(FundingStage.isValidFundingLevel("ps"));
     }
 
     @Test


### PR DESCRIPTION
- Ability to add pre-seed and seed stages with 'f/ps' and 'f/s' respectively.
- Made funding stages agnostic to upper-case / lower-casing i.e. 'f/A' and 'f/a' are both accepted.
- Updated UI display for the new funding stages.

<img width="732" alt="Screenshot 2024-03-15 at 11 25 06 AM" src="https://github.com/AY2324S2-CS2103T-W09-2/tp/assets/100367948/0826ad71-ba2f-4bcb-9e9c-3594bcaadf16">
