### PR TITLE
feat: update find command

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -15,7 +15,7 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
-    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
+    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d startups listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
 

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -5,7 +5,12 @@ import static java.util.Objects.requireNonNull;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.model.Model;
+import seedu.address.model.person.FundingStageContainsKeywordsPredicate;
+import seedu.address.model.person.IndustryContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.Person;
+
+import java.util.function.Predicate;
 
 /**
  * Finds and lists all persons in address book whose name contains any of the argument keywords.
@@ -20,11 +25,18 @@ public class FindCommand extends Command {
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " alice bob charlie";
 
-    private final NameContainsKeywordsPredicate predicate;
+    private final Predicate<Person> predicate;
 
     public FindCommand(NameContainsKeywordsPredicate predicate) {
         this.predicate = predicate;
     }
+    public FindCommand(IndustryContainsKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
+    public FindCommand(FundingStageContainsKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
+
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -2,6 +2,8 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.function.Predicate;
+
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.model.Model;
@@ -10,7 +12,6 @@ import seedu.address.model.person.IndustryContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 
-import java.util.function.Predicate;
 
 /**
  * Finds and lists all persons in address book whose name contains any of the argument keywords.
@@ -20,10 +21,13 @@ public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
-            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " alice bob charlie";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all startups that contain any of "
+            + "the specified keywords (case-insensitive) of either name / industry / funding stage"
+            + " and displays them as a list with index numbers.\n"
+            + "Example: " + COMMAND_WORD + " n/ Names \n"
+            + "Example: " + COMMAND_WORD + " i/ Industries \n"
+            + "Example: " + COMMAND_WORD + " f/ Funding Stages \n"
+            + "Example: " + COMMAND_WORD + " f/ B C";;
 
     private final Predicate<Person> predicate;
 

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -6,6 +6,8 @@ import java.util.Arrays;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.FundingStageContainsKeywordsPredicate;
+import seedu.address.model.person.IndustryContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 
 /**
@@ -19,15 +21,36 @@ public class FindCommandParser implements Parser<FindCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {
+        FindCommand findCommand = null;
         String trimmedArgs = args.trim();
         if (trimmedArgs.isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        String[] nameKeywords = trimmedArgs.split("\\s+");
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, CliSyntax.PREFIX_NAME,
+                        CliSyntax.PREFIX_INDUSTRY,
+                        CliSyntax.PREFIX_FUNDING_STAGE
+                );
 
-        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        String[] nameKeywords = new String[0];
+        String[] industryKeywords = new String[0];
+        String[] fundingStageKeywords = new String[0];
+        if (argMultimap.getValue(CliSyntax.PREFIX_NAME).isPresent()) {
+            nameKeywords = argMultimap.getValue(CliSyntax.PREFIX_NAME).get().split("\\s+");
+            findCommand = new FindCommand(new NameContainsKeywordsPredicate((Arrays.asList(nameKeywords))));
+        }
+        if (argMultimap.getValue(CliSyntax.PREFIX_INDUSTRY).isPresent()) {
+            industryKeywords = argMultimap.getValue(CliSyntax.PREFIX_INDUSTRY).get().split("\\s+");
+            findCommand = new FindCommand(new IndustryContainsKeywordsPredicate((Arrays.asList(industryKeywords))));
+        }
+        if (argMultimap.getValue(CliSyntax.PREFIX_FUNDING_STAGE).isPresent()) {
+            fundingStageKeywords = argMultimap.getValue(CliSyntax.PREFIX_FUNDING_STAGE).get().split("\\s+");
+            findCommand = new FindCommand(new FundingStageContainsKeywordsPredicate((Arrays.asList(fundingStageKeywords))));
+        }
+
+        return findCommand;
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -4,6 +4,7 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.Arrays;
 
+import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.FundingStageContainsKeywordsPredicate;
@@ -40,14 +41,16 @@ public class FindCommandParser implements Parser<FindCommand> {
         if (argMultimap.getValue(CliSyntax.PREFIX_NAME).isPresent()) {
             nameKeywords = argMultimap.getValue(CliSyntax.PREFIX_NAME).get().split("\\s+");
             findCommand = new FindCommand(new NameContainsKeywordsPredicate((Arrays.asList(nameKeywords))));
-        }
-        if (argMultimap.getValue(CliSyntax.PREFIX_INDUSTRY).isPresent()) {
+        } else if (argMultimap.getValue(CliSyntax.PREFIX_INDUSTRY).isPresent()) {
             industryKeywords = argMultimap.getValue(CliSyntax.PREFIX_INDUSTRY).get().split("\\s+");
             findCommand = new FindCommand(new IndustryContainsKeywordsPredicate((Arrays.asList(industryKeywords))));
-        }
-        if (argMultimap.getValue(CliSyntax.PREFIX_FUNDING_STAGE).isPresent()) {
+        } else if (argMultimap.getValue(CliSyntax.PREFIX_FUNDING_STAGE).isPresent()) {
             fundingStageKeywords = argMultimap.getValue(CliSyntax.PREFIX_FUNDING_STAGE).get().split("\\s+");
-            findCommand = new FindCommand(new FundingStageContainsKeywordsPredicate((Arrays.asList(fundingStageKeywords))));
+            findCommand = new FindCommand(
+                    new FundingStageContainsKeywordsPredicate((Arrays.asList(fundingStageKeywords))));
+        } else {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    EditCommand.MESSAGE_USAGE));
         }
 
         return findCommand;

--- a/src/main/java/seedu/address/model/person/FundingStageContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/FundingStageContainsKeywordsPredicate.java
@@ -1,10 +1,11 @@
 package seedu.address.model.person;
 
+import java.util.List;
+import java.util.function.Predicate;
+
 import seedu.address.commons.util.StringUtil;
 import seedu.address.commons.util.ToStringBuilder;
 
-import java.util.List;
-import java.util.function.Predicate;
 
 /**
  * Tests that a {@code Person}'s {@code FundingStage} matches any of the keywords given.
@@ -33,7 +34,8 @@ public class FundingStageContainsKeywordsPredicate implements Predicate<Person> 
             return false;
         }
 
-        FundingStageContainsKeywordsPredicate otherFundingStageContainsKeywordsPredicate = (FundingStageContainsKeywordsPredicate) other;
+        FundingStageContainsKeywordsPredicate otherFundingStageContainsKeywordsPredicate =
+                (FundingStageContainsKeywordsPredicate) other;
         return keywords.equals(otherFundingStageContainsKeywordsPredicate.keywords);
     }
 

--- a/src/main/java/seedu/address/model/person/FundingStageContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/FundingStageContainsKeywordsPredicate.java
@@ -1,0 +1,44 @@
+package seedu.address.model.person;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.commons.util.ToStringBuilder;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code Person}'s {@code FundingStage} matches any of the keywords given.
+ */
+public class FundingStageContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public FundingStageContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getFundingStage().value, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof FundingStageContainsKeywordsPredicate)) {
+            return false;
+        }
+
+        FundingStageContainsKeywordsPredicate otherFundingStageContainsKeywordsPredicate = (FundingStageContainsKeywordsPredicate) other;
+        return keywords.equals(otherFundingStageContainsKeywordsPredicate.keywords);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("keywords", keywords).toString();
+    }
+}

--- a/src/main/java/seedu/address/model/person/IndustryContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/IndustryContainsKeywordsPredicate.java
@@ -1,10 +1,12 @@
 package seedu.address.model.person;
 
+import java.util.List;
+import java.util.function.Predicate;
+
 import seedu.address.commons.util.StringUtil;
 import seedu.address.commons.util.ToStringBuilder;
 
-import java.util.List;
-import java.util.function.Predicate;
+
 
 /**
  * Tests that a {@code Startup}'s {@code Industry} matches any of the keywords given.
@@ -33,7 +35,8 @@ public class IndustryContainsKeywordsPredicate implements Predicate<Person> {
             return false;
         }
 
-        IndustryContainsKeywordsPredicate otherIndustryContainsKeywordsPredicate = (IndustryContainsKeywordsPredicate) other;
+        IndustryContainsKeywordsPredicate otherIndustryContainsKeywordsPredicate =
+                (IndustryContainsKeywordsPredicate) other;
         return keywords.equals(otherIndustryContainsKeywordsPredicate.keywords);
     }
 

--- a/src/main/java/seedu/address/model/person/IndustryContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/IndustryContainsKeywordsPredicate.java
@@ -1,0 +1,44 @@
+package seedu.address.model.person;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.commons.util.ToStringBuilder;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code Startup}'s {@code Industry} matches any of the keywords given.
+ */
+public class IndustryContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public IndustryContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getIndustry().value, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof IndustryContainsKeywordsPredicate)) {
+            return false;
+        }
+
+        IndustryContainsKeywordsPredicate otherIndustryContainsKeywordsPredicate = (IndustryContainsKeywordsPredicate) other;
+        return keywords.equals(otherIndustryContainsKeywordsPredicate.keywords);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("keywords", keywords).toString();
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/FindByFundingStageCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindByFundingStageCommandTest.java
@@ -18,46 +18,47 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.FundingStageContainsKeywordsPredicate;
 
 /**
- * Contains integration tests (interaction with the Model) for {@code FindCommand}.
+ * Contains integration tests (interaction with the Model) for {@code FindByFundingStage}.
  */
-public class FindCommandTest {
+public class FindByFundingStageCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
     private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
     public void equals() {
-        NameContainsKeywordsPredicate firstPredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("first"));
-        NameContainsKeywordsPredicate secondPredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("second"));
+        // Tests for find by names
+        FundingStageContainsKeywordsPredicate firstFundingStagePredicate =
+                new FundingStageContainsKeywordsPredicate(Collections.singletonList("A"));
+        FundingStageContainsKeywordsPredicate secondFundingStagePredicate =
+                new FundingStageContainsKeywordsPredicate(Collections.singletonList("Seed"));
 
-        FindCommand findFirstCommand = new FindCommand(firstPredicate);
-        FindCommand findSecondCommand = new FindCommand(secondPredicate);
+        FindCommand findFirstFundingStageCommand = new FindCommand(firstFundingStagePredicate);
+        FindCommand findSecondFundingStageCommand = new FindCommand(secondFundingStagePredicate);
 
         // same object -> returns true
-        assertTrue(findFirstCommand.equals(findFirstCommand));
+        assertTrue(findFirstFundingStageCommand.equals(findFirstFundingStageCommand));
 
         // same values -> returns true
-        FindCommand findFirstCommandCopy = new FindCommand(firstPredicate);
-        assertTrue(findFirstCommand.equals(findFirstCommandCopy));
+        FindCommand findFirstFundingStageCommandCopy = new FindCommand(firstFundingStagePredicate);
+        assertTrue(findFirstFundingStageCommand.equals(findFirstFundingStageCommandCopy));
 
         // different types -> returns false
-        assertFalse(findFirstCommand.equals(1));
+        assertFalse(findFirstFundingStageCommand.equals(1));
 
         // null -> returns false
-        assertFalse(findFirstCommand.equals(null));
+        assertFalse(findFirstFundingStageCommand.equals(null));
 
         // different person -> returns false
-        assertFalse(findFirstCommand.equals(findSecondCommand));
+        assertFalse(findFirstFundingStageCommand.equals(findSecondFundingStageCommand));
     }
 
     @Test
     public void execute_zeroKeywords_noPersonFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
-        NameContainsKeywordsPredicate predicate = preparePredicate(" ");
+        FundingStageContainsKeywordsPredicate predicate = preparePredicate(" ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -67,7 +68,7 @@ public class FindCommandTest {
     @Test
     public void execute_multipleKeywords_multiplePersonsFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
-        NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
+        FundingStageContainsKeywordsPredicate predicate = preparePredicate("C");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -76,16 +77,17 @@ public class FindCommandTest {
 
     @Test
     public void toStringMethod() {
-        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Arrays.asList("keyword"));
+        FundingStageContainsKeywordsPredicate predicate =
+                new FundingStageContainsKeywordsPredicate(Arrays.asList("keyword"));
         FindCommand findCommand = new FindCommand(predicate);
         String expected = FindCommand.class.getCanonicalName() + "{predicate=" + predicate + "}";
         assertEquals(expected, findCommand.toString());
     }
 
     /**
-     * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
+     * Parses {@code userInput} into a {@code FundingStageContainsKeywordsPredicate}.
      */
-    private NameContainsKeywordsPredicate preparePredicate(String userInput) {
-        return new NameContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    private FundingStageContainsKeywordsPredicate preparePredicate(String userInput) {
+        return new FundingStageContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/FindByIndustryCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindByIndustryCommandTest.java
@@ -1,0 +1,92 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.CARL;
+import static seedu.address.testutil.TypicalPersons.ELLE;
+import static seedu.address.testutil.TypicalPersons.FIONA;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.IndustryContainsKeywordsPredicate;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code FindByIndustryCommand}.
+ */
+public class FindByIndustryCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void equals() {
+        // Tests for find by names
+        IndustryContainsKeywordsPredicate firstIndustryPredicate =
+                new IndustryContainsKeywordsPredicate(Collections.singletonList("first"));
+        IndustryContainsKeywordsPredicate secondIndustryPredicate =
+                new IndustryContainsKeywordsPredicate(Collections.singletonList("second"));
+
+        FindCommand findFirstIndustryCommand = new FindCommand(firstIndustryPredicate);
+        FindCommand findSecondIndustryCommand = new FindCommand(secondIndustryPredicate);
+
+        // same object -> returns true
+        assertTrue(findFirstIndustryCommand.equals(findFirstIndustryCommand));
+
+        // same values -> returns true
+        FindCommand findFirstIndustryCommandCopy = new FindCommand(firstIndustryPredicate);
+        assertTrue(findFirstIndustryCommand.equals(findFirstIndustryCommandCopy));
+
+        // different types -> returns false
+        assertFalse(findFirstIndustryCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(findFirstIndustryCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(findFirstIndustryCommand.equals(findSecondIndustryCommand));
+    }
+
+    @Test
+    public void execute_zeroKeywords_noPersonFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        IndustryContainsKeywordsPredicate predicate = preparePredicate(" ");
+        FindCommand command = new FindCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_multipleKeywords_multiplePersonsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
+        IndustryContainsKeywordsPredicate predicate = preparePredicate("web3");
+        FindCommand command = new FindCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void toStringMethod() {
+        IndustryContainsKeywordsPredicate predicate = new IndustryContainsKeywordsPredicate(Arrays.asList("keyword"));
+        FindCommand findCommand = new FindCommand(predicate);
+        String expected = FindCommand.class.getCanonicalName() + "{predicate=" + predicate + "}";
+        assertEquals(expected, findCommand.toString());
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code IndustryContainsKeywordsPredicate}.
+     */
+    private IndustryContainsKeywordsPredicate preparePredicate(String userInput) {
+        return new IndustryContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/FindByNameCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindByNameCommandTest.java
@@ -1,0 +1,92 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.CARL;
+import static seedu.address.testutil.TypicalPersons.ELLE;
+import static seedu.address.testutil.TypicalPersons.FIONA;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.NameContainsKeywordsPredicate;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code FindByNameCommand}.
+ */
+public class FindByNameCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void equals() {
+        // Tests for find by names
+        NameContainsKeywordsPredicate firstNamePredicate =
+                new NameContainsKeywordsPredicate(Collections.singletonList("first"));
+        NameContainsKeywordsPredicate secondNamePredicate =
+                new NameContainsKeywordsPredicate(Collections.singletonList("second"));
+
+        FindCommand findFirstNameCommand = new FindCommand(firstNamePredicate);
+        FindCommand findSecondNameCommand = new FindCommand(secondNamePredicate);
+
+        // same object -> returns true
+        assertTrue(findFirstNameCommand.equals(findFirstNameCommand));
+
+        // same values -> returns true
+        FindCommand findFirstNameCommandCopy = new FindCommand(firstNamePredicate);
+        assertTrue(findFirstNameCommand.equals(findFirstNameCommandCopy));
+
+        // different types -> returns false
+        assertFalse(findFirstNameCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(findFirstNameCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(findFirstNameCommand.equals(findSecondNameCommand));
+    }
+
+    @Test
+    public void execute_zeroKeywords_noPersonFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        NameContainsKeywordsPredicate predicate = preparePredicate(" ");
+        FindCommand command = new FindCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_multipleKeywords_multiplePersonsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
+        NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
+        FindCommand command = new FindCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void toStringMethod() {
+        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Arrays.asList("keyword"));
+        FindCommand findCommand = new FindCommand(predicate);
+        String expected = FindCommand.class.getCanonicalName() + "{predicate=" + predicate + "}";
+        assertEquals(expected, findCommand.toString());
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
+     */
+    private NameContainsKeywordsPredicate preparePredicate(String userInput) {
+        return new NameContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    }
+}

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -32,16 +32,16 @@ public class TypicalPersons {
             .withEmail("johnd@example.com").withPhone("98765432").withNote("Smelly guy")
             .withTags("owesMoney", "friends").build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
-            .withEmail("heinz@example.com").withIndustry("finance").withFundingStage("A")
+            .withEmail("heinz@example.com").withIndustry("web3").withFundingStage("C")
             .withAddress("wall street").build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
             .withEmail("cornelia@example.com").withIndustry("finance").withFundingStage("A")
             .withAddress("10th street").withTags("friends").build();
     public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")
-            .withEmail("werner@example.com").withIndustry("finance").withFundingStage("A")
+            .withEmail("werner@example.com").withIndustry("web3").withFundingStage("C")
             .withAddress("michegan ave").build();
     public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")
-            .withEmail("lydia@example.com").withIndustry("finance").withFundingStage("A")
+            .withEmail("lydia@example.com").withIndustry("web3").withFundingStage("C")
             .withAddress("little tokyo").build();
     public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("9482442")
             .withEmail("anna@example.com").withIndustry("finance").withFundingStage("A")


### PR DESCRIPTION
* Update `find` command to enable find by industries and find by funding stages
* Find command syntaxes are as follow:
  * `find n/ [names]`
  * `find i/ [industries]`
  * `find f/ [funding stages]`
* For instance, `find i/web3` will list the startups that focus on web3:

![image](https://github.com/AY2324S2-CS2103T-W09-2/tp/assets/108997339/1d868f4a-a18e-4efb-903e-a02e33433484)

* Similarly, `find f/a b` will list the startups that are currently in the series A and series B funding stage:

![image](https://github.com/AY2324S2-CS2103T-W09-2/tp/assets/108997339/742e43e3-23bc-47e7-bdcc-d3d12bb29bde)

* closes #7 